### PR TITLE
CRAYSAT-1620: Use authentication when accessing csm-python-modules

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -44,6 +44,9 @@ pipeline {
     stages {
         stage('Build Prep') {
             steps {
+                script {
+                    jenkinsUtils.writeNetRc()
+                }
                 sh 'make prep'
             }
         }

--- a/build_scripts/runBuildPrep.sh
+++ b/build_scripts/runBuildPrep.sh
@@ -25,7 +25,7 @@
 
 # Set PIP_EXTRA_INDEX_URL to pull internal packages from internal locations:
 # artifactory.algol60.net/artifactory/csm-python-modules/simple/ - repo containing cray-product-catalog
-# arti.dev.cray.com/artifactory/internal-pip-stable-local/ - repo containing nexusctl
+# arti.hpc.amslabs.hpecorp.net/artifactory/internal-pip-stable-local/ - repo containing nexusctl
 PIP_EXTRA_INDEX_URL="https://artifactory.algol60.net/artifactory/csm-python-modules/simple/
-  https://arti.dev.cray.com/artifactory/internal-pip-stable-local/" pip3 install -r requirements.txt
+  https://arti.hpc.amslabs.hpecorp.net/artifactory/internal-pip-stable-local/" pip3 install -r requirements.txt
 pip3 install -r requirements-dev.txt


### PR DESCRIPTION
This commit adds creation of a .netrc file on the Jenkins host on which the build is running. The intention of this file is to provide credential authentication in the case when the package's dependencies are being installed in a VirtualEnv on the host to facilitate running unit tests. This uses the utility jenkinsUtils.writeNetRc() found in csm-shared-library.

Test Description: Built package in Jenkins