### PR TITLE
CRAYSAT-1750: Allow PyYAML >= 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2023-07-31
+
+### Changed
+- Allow PyYAML 6.x versions so applications using this library can pull in
+  PyYAML 6.0.1 to fix a Cython 3.0 compatibility issue.
+- Require a newer version of `kubernetes` that is more in sync with Kubernetes
+  1.21 included in CSM 1.5.
+
 ## [2.3.2] - 2022-06-24
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,6 @@
 cray-product-catalog==1.3.2
 nexusctl >= 1.1.1, < 2.0
 jsonschema >=3.2.0, < 4.0
-kubernetes >= 11.0, < 12.0
-# Require version < 6.0 of PyYAML because shasta_install_utility_common/products.py
-# imports YAMLLoadWarning which is not present in version >= 6.0.
-pyyaml >= 5.4, < 6.0
+kubernetes >= 21.0
+pyyaml < 7.0
 urllib3

--- a/shasta_install_utility_common/products.py
+++ b/shasta_install_utility_common/products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,6 @@ from base64 import b64decode
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
-import warnings
 
 from cray_product_catalog.schema.validate import validate
 from jsonschema.exceptions import ValidationError
@@ -40,7 +39,7 @@ from nexusctl import DockerApi, DockerClient, NexusApi, NexusClient
 from nexusctl.common import DEFAULT_DOCKER_REGISTRY_API_BASE_URL, DEFAULT_NEXUS_API_BASE_URL
 from urllib3.exceptions import MaxRetryError
 from urllib.error import HTTPError
-from yaml import safe_load, safe_dump, YAMLError, YAMLLoadWarning
+from yaml import safe_load, safe_dump, YAMLError
 
 
 from shasta_install_utility_common.constants import (
@@ -114,9 +113,7 @@ class ProductCatalog:
                 Kubernetes configuration.
         """
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=YAMLLoadWarning)
-                load_kube_config()
+            load_kube_config()
             return CoreV1Api()
         except ConfigException as err:
             raise ProductInstallException(f'Unable to load kubernetes configuration: {err}.')


### PR DESCRIPTION
## Summary and Scope
Update the version constraints in `requirements.txt` to allow PyYAML >=
6.0. This allows packages which require PyYAML 6.0.1 to address the
Cython 3.0 incompatibility to continue building.

The main changes between PyYAML 5.x and 6.x are:

* `yaml.load` always requires a `Loader` argument
* Python 2.7 is no longer supported
* `YAMLLoadWarning` is gone

Only this last one affects this code. This is fixed by dropping the code
that catches the `YAMLLoadWarning`. We no longer need to catch this
warning anymore. The `kubernetes` library has not emitted that warning
since v10.0.0.

Also require a newer version of `kubernetes` to more closely match the
CSM 1.5 version of Kubernetes.

## Issues and Related PRs

* Resolves [CRAYSAT-1750](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1750)

## Testing

### Tested on:

  * dev system TBD

### Test description:

Will be tested by pulling this version into a build of sat-install-utility and then testing `prodmgr activate sat VERSION`.

## Risks and Mitigations

Pretty low risk. This just updates some dependencies and loosens the constraint on the PyYAML version, so that applications which use this library can specify the PyYAML and Kubernetes versions they need.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

