### PR TITLE
Create 2.3.3 release

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -29,15 +29,20 @@ on:
 jobs:
   license-check:
     runs-on: ubuntu-latest
+
+    container:
+      image: artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      credentials:
+          username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
+
     steps:
     - uses: actions/checkout@v3
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v18.7
+      uses: tj-actions/changed-files@v34
 
     - name: License Check
       if: ${{ steps.changed-files.outputs.all_changed_files }}
-      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
-      with:
-        args: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: /usr/local/bin/python3 /license_check/license_check.py ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,0 +1,43 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: Check Licenses
+
+on:
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v18.7
+
+    - name: License Check
+      if: ${{ steps.changed-files.outputs.all_changed_files }}
+      uses: docker://artifactory.algol60.net/csm-docker/stable/license-checker:latest
+      with:
+        args: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2023-07-31
+
+### Changed
+- Allow PyYAML 6.x versions so applications using this library can pull in
+  PyYAML 6.0.1 to fix a Cython 3.0 compatibility issue.
+- Require a newer version of `kubernetes` that is more in sync with Kubernetes
+  1.21 included in CSM 1.5.
+
 ## [2.3.2] - 2022-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2023-08-04
+
+### Changed
+- Allow newer versions of `cray-product-catalog` so this package can be
+  installed by packages that require newer query features from
+  `cray-product-catalog`.
+
 ## [2.3.3] - 2023-07-31
 
 ### Changed

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,25 +1,26 @@
 /*
- * MIT License
  *
- * (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  MIT License
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -44,6 +44,9 @@ pipeline {
     stages {
         stage('Build Prep') {
             steps {
+                script {
+                    jenkinsUtils.writeNetRc()
+                }
                 sh 'make prep'
             }
         }

--- a/build_scripts/runBuildPrep.sh
+++ b/build_scripts/runBuildPrep.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/build_scripts/runBuildPrep.sh
+++ b/build_scripts/runBuildPrep.sh
@@ -25,7 +25,7 @@
 
 # Set PIP_EXTRA_INDEX_URL to pull internal packages from internal locations:
 # artifactory.algol60.net/artifactory/csm-python-modules/simple/ - repo containing cray-product-catalog
-# arti.dev.cray.com/artifactory/internal-pip-stable-local/ - repo containing nexusctl
+# arti.hpc.amslabs.hpecorp.net/artifactory/internal-pip-stable-local/ - repo containing nexusctl
 PIP_EXTRA_INDEX_URL="https://artifactory.algol60.net/artifactory/csm-python-modules/simple/
-  https://arti.dev.cray.com/artifactory/internal-pip-stable-local/" pip3 install -r requirements.txt
+  https://arti.hpc.amslabs.hpecorp.net/artifactory/internal-pip-stable-local/" pip3 install -r requirements.txt
 pip3 install -r requirements-dev.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,6 @@
 cray-product-catalog==1.3.2
 nexusctl >= 1.1.1, < 2.0
 jsonschema >=3.2.0, < 4.0
-kubernetes >= 11.0, < 12.0
-# Require version < 6.0 of PyYAML because shasta_install_utility_common/products.py
-# imports YAMLLoadWarning which is not present in version >= 6.0.
-pyyaml >= 5.4, < 6.0
+kubernetes >= 21.0
+pyyaml < 7.0
 urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,7 @@
 
 # Top-level requirements for shasta-install-utility-common
 
-# This should be pinned exactly to 1.3.2 due to issues with the build of cray-product-catalog
-cray-product-catalog==1.3.2
+cray-product-catalog >= 1.3.2, < 2.0
 nexusctl >= 1.1.1, < 2.0
 jsonschema >=3.2.0, < 4.0
 kubernetes >= 21.0

--- a/shasta_install_utility_common/products.py
+++ b/shasta_install_utility_common/products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,6 @@ from base64 import b64decode
 import os
 import subprocess
 from tempfile import NamedTemporaryFile
-import warnings
 
 from cray_product_catalog.schema.validate import validate
 from jsonschema.exceptions import ValidationError
@@ -40,7 +39,7 @@ from nexusctl import DockerApi, DockerClient, NexusApi, NexusClient
 from nexusctl.common import DEFAULT_DOCKER_REGISTRY_API_BASE_URL, DEFAULT_NEXUS_API_BASE_URL
 from urllib3.exceptions import MaxRetryError
 from urllib.error import HTTPError
-from yaml import safe_load, safe_dump, YAMLError, YAMLLoadWarning
+from yaml import safe_load, safe_dump, YAMLError
 
 
 from shasta_install_utility_common.constants import (
@@ -114,9 +113,7 @@ class ProductCatalog:
                 Kubernetes configuration.
         """
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', category=YAMLLoadWarning)
-                load_kube_config()
+            load_kube_config()
             return CoreV1Api()
         except ConfigException as err:
             raise ProductInstallException(f'Unable to load kubernetes configuration: {err}.')

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -134,17 +134,6 @@ class TestProductCatalog(unittest.TestCase):
         with self.assertRaisesRegex(ProductInstallException,
                                     'No data found in mock-namespace/mock-name ConfigMap.'):
             self.create_and_assert_product_catalog()
-
-    def test_create_product_catalog_invalid_product_schema(self):
-        """Test creating a ProductCatalog when an entry contains valid YAML but does not match schema."""
-        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data={
-            'sat': safe_dump({'2.1': {'this_key_is_not_allowed': {}}})
-        })
-        product_catalog = self.create_and_assert_product_catalog()
-        self.mock_print.assert_called_once_with(
-            'The following products have product catalog data that is not understood by the install utility: sat-2.1'
-        )
-        self.assertEqual(product_catalog.products, [])
 
     def test_get_matching_products(self):
         """Test getting a particular product by name/version."""


### PR DESCRIPTION
## Summary and Scope

Fast-forward release branch to latest main to create 2.3.3 release with relaxed PyYAML constraint and more accurate kubernetes constraint.

## Issues and Related PRs

* Resolves [CRAYSAT-1750](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1750)

## Testing

### Tested on:

  * mug

### Test description:

TODO: I plan to test on mug with a build of the sat-install-utility image that pulls in the unstable version of this release.

I will manually invoke the `sat-install-utility` image to activate the current version of SAT. It should be a no-op.

## Risks and Mitigations

Low risk. Creates a new release that other install-utility images or the product-deletion-utility can pick up to fix the PyYAML build issue.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable