### PR TITLE
CRAYSAT-1750: Relax cray-product-catalog constraint

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] - 2023-08-04
+
+### Changed
+- Allow newer versions of `cray-product-catalog` so this package can be
+  installed by packages that require newer query features from
+  `cray-product-catalog`.
+
 ## [2.3.3] - 2023-07-31
 
 ### Changed

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,25 +1,26 @@
 /*
- * MIT License
  *
- * (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  MIT License
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
  *
  */
 

--- a/build_scripts/runBuildPrep.sh
+++ b/build_scripts/runBuildPrep.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,7 @@
 
 # Top-level requirements for shasta-install-utility-common
 
-# This should be pinned exactly to 1.3.2 due to issues with the build of cray-product-catalog
-cray-product-catalog==1.3.2
+cray-product-catalog >= 1.3.2, < 2.0
 nexusctl >= 1.1.1, < 2.0
 jsonschema >=3.2.0, < 4.0
 kubernetes >= 21.0

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -134,17 +134,6 @@ class TestProductCatalog(unittest.TestCase):
         with self.assertRaisesRegex(ProductInstallException,
                                     'No data found in mock-namespace/mock-name ConfigMap.'):
             self.create_and_assert_product_catalog()
-
-    def test_create_product_catalog_invalid_product_schema(self):
-        """Test creating a ProductCatalog when an entry contains valid YAML but does not match schema."""
-        self.mock_k8s_api.read_namespaced_config_map.return_value = Mock(data={
-            'sat': safe_dump({'2.1': {'this_key_is_not_allowed': {}}})
-        })
-        product_catalog = self.create_and_assert_product_catalog()
-        self.mock_print.assert_called_once_with(
-            'The following products have product catalog data that is not understood by the install utility: sat-2.1'
-        )
-        self.assertEqual(product_catalog.products, [])
 
     def test_get_matching_products(self):
         """Test getting a particular product by name/version."""


### PR DESCRIPTION


## Summary and Scope

Currently, `sat-install-utility` depends on cray-product-catalog >= 1.6.0 and on `shasta-install-utility-common`. However, since `shasta-install-utility-common` depends on exactly ersion 1.3.2 of `cray-product-catalog`, these dependencies can't be resolved. Fix this by allowing the `cray-product-catalog` version required by this package to be >= 1.3.2 instead of == 1.3.2.

Consistent with semver, the changes between 1.3.2 and 1.8.12 of cray-product-catalog seem to just be additions. The interfaces haven't change in a backwards-incompatible way.

## Issues and Related PRs

* Resolves [CRAYSAT-1750](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1750)

## Testing

### Tested on:

  * mug

### Test description:

Testing to be done before release by using `sat-install-utility` which will pull in this new version of `shasta-install-utility-common`.

## Risks and Mitigations

`cray-product-catalog` 1.8.12 should be backwards compatible with 1.3.2 based on a quick look at its changelog and how it's used in this code.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

